### PR TITLE
make sure org-msg-org-to-xml uses right html buffer

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -558,10 +558,10 @@ absolute paths."
 	    (org-html-head-include-scripts nil)
 	    (org-html-head-include-default-style nil)
 	    (org-msg-export-in-progress t))
-	(org-html-export-as-html))
-      (let ((xml (org-msg-html-buffer-to-xml base)))
-	(kill-buffer)
-	xml))))
+	(set-buffer  (org-html-export-as-html))
+        (let ((xml (org-msg-html-buffer-to-xml base)))
+	  (kill-buffer)
+	  xml)))))
 
 (defun org-msg-load-css ()
   "Load the CSS definition according to `org-msg-enforce-css'."


### PR DESCRIPTION
When `org-export-show-temporary-export-buffer` is `nil`,
`org-msg-org-to-xml` would try to parse the **org** buffer rather than
the html export buffer.  This change hopefully fixes that.

Appears to fix #6 