### PR TITLE
Don't do rfc 2045 decoding on the mu4e html body

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -351,8 +351,7 @@ file."
 			     value)))))
       (with-temp-buffer
 	(save-excursion
-	  (insert html)
-	  (quoted-printable-decode-region (point-min) (point-max)))
+	  (insert html))
 	;; Remove everything before html tag
 	(save-excursion
 	  (if (re-search-forward "^<html\\(.*?\\)>" nil t)


### PR DESCRIPTION
It is not encoded, so this isn't necessary, at least in mu4e 1.4.x.
Doing this corrupts the temporary HTML file that is saved.

Also add the tab indenting settings to the local file props.

Fix https://github.com/jeremy-compostella/org-msg/issues/46