### PR TITLE
Treat org-msg buffer prep as non-modifying changes

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -895,7 +895,8 @@ area."
 	      (org-escape-code-in-region (point) (point-max))))
 	  (when org-msg-signature
 	    (insert org-msg-signature))
-	  (org-msg-edit-mode)))
+	  (org-msg-edit-mode))
+	(set-buffer-modified-p nil))
       (if (org-msg-message-fetch-field "to")
 	  (org-msg-goto-body)
 	(message-goto-to)))))


### PR DESCRIPTION
This makes it so, without additional edits to the message, the user is
not prompted to save the modified buffer if they change their mind and
decide to kill the buffer after opening it. Closes #50