### PR TITLE
Use cl-lib functions instead of cl.el functions

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -325,7 +325,7 @@ actual email we want to reply to.  The
 images.  This function returns the absolute path of the HTML
 file."
   (let* ((browse-url-browser-function #'ignore)
-	 (save (copy-list gnus-article-browse-html-temp-list)))
+	 (save (cl-copy-list gnus-article-browse-html-temp-list)))
     (cl-letf (((symbol-function 'gnus-summary-show-article) #'ignore))
       (save-window-excursion
 	(gnus-article-browse-html-article)))
@@ -574,9 +574,9 @@ absolute paths.  Base is also used to locate SVG objects tag file
 and include the SVG content into the email XML tree."
   (let ((dirs (list base (temporary-file-directory))))
     (cl-flet* ((get-file-path (file)
-		(let ((paths (mapcar* 'concat dirs
-				      (make-list (length dirs) file))))
-		  (car (delete-if-not 'file-exists-p paths))))
+		(let ((paths (cl-mapcar 'concat dirs
+					(make-list (length dirs) file))))
+		  (car (cl-delete-if-not 'file-exists-p paths))))
 	       (make-img-abs (xml)
 		(when (eq (car xml) 'img)
 		  (let ((src (assq 'src (cadr xml))))


### PR DESCRIPTION
This fixes following byte-compile warnings

```
org-msg.el:328:27:Warning: function ‘copy-list’ from cl package called at runtime
org-msg.el:578:64:Warning: function ‘mapcar*’ from cl package called at runtime
org-msg.el:579:54:Warning: function ‘delete-if-not’ from cl package called at runtime
```