### PR TITLE
Allow sending of any combination of text and html

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,7 +47,7 @@ The following is my configuration which you can use as an example.
 	org-msg-startup "hidestars indent inlineimages"
 	org-msg-greeting-fmt "\nHi *%s*,\n\n"
 	org-msg-greeting-name-limit 3
-	org-msg-text-plain-alternative t
+	org-msg-default-alternatives '(html text)
 	org-msg-signature "
 
   Regards,
@@ -61,7 +61,7 @@ The following is my configuration which you can use as an example.
 
 The ~org-msg-greeting-fmt~ can be customized to configure the default greeting message.  If this format contains a ~%s~ token it is automatically replaced with the first name of the person you are replying to.  If ~org-msg-greeting-fmt-mailto~ is t, the first name it is formatted as mailto link.
 
-If ~org-msg-text-plain-alternative~ is ~t~, *OrgMsg* generates an ASCII export of the message and attach this export as a ~text/plain~ alternative to the HTML email.
+The types of MIME alternatives that are sent can be modified by editing the ~:alternatives:~ property on each message. For example, setting this property to ~(html text)~ will send both text and HTML alternatives to your message, whereas ~(html)~ or ~(text)~ will just send HTML or plain text respectively. The default value of ~:alternatives:~ can be set with ~org-msg-default-alternatives~. If you want to add your own custom exporters, this can be done by modifying ~org-msg-alternative-exporters~.
 
 In order to avoid CSS conflict, *OrgMsg* performs inline replacement when it generates the final HTML message.  See the ~org-msg-enforce-css~ variable to customize the style (and the default ~org-msg-default-style~ variable for reference).
 


### PR DESCRIPTION
- Add a new property to messages: `format` which can take a value of
'text', 'html', or 'both'. 'html' is similar to the old default
behaviour, 'both' is similar to the old functionality when
`org-msg-text-plain-alternative` was non-nil, and 'text' sends only
text/plain and no 'html'
- Add a custom option to configure the default value of this property
- Refactor `org-msg-prepare-to-send` to handle the new functionality
- Also refactors `org-msg-mml-into-multipart-related` so that MIME
structures are as close as possible to when recursive mime is present.

Creating this PR now that it is in a mostly working state

My knowledge of mml and MIME are not very deep, so please let me know if I have made any mistakes with the refactoring of `org-msg-prepare-to-send` or with `org-msg-mml-into-multipart-related`.

This patch should work with #69 to allow for much greater functionality and configurability with sending text email while still remaining in `org-msg`

TODO
- Add command to cycle through different `format` properties for easy switching between text, html, and both
- ~Test when `mml-expand-all-html-into-multipart-related` is present~ DONE, seems to work