### PR TITLE
Save the reply-to message with the correct coding-system

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -606,8 +606,8 @@ selectors on class `org-msg-reply-header-class', it sets the
 style mailto anchor link style appropriately."
   (with-temp-buffer
     (insert str)
-    (let ((name-regexp "\\\([a-zA-Z\"][0-9a-zA-Z ,\"\(\)@\./\-]+\\\)")
-	  (mail-regexp "<\\\([A-Za-z0-9@\.]+\\\)>")
+    (let ((name-regexp "\\([[:alpha:]\"][[:alnum:] ,\"()@./-]+\\)")
+	  (mail-regexp "<\\([A-Za-z0-9@.]+\\)>")
 	  (cursor (goto-char (point-min)))
 	  (style (org-msg-build-style 'a org-msg-reply-header-class css))
 	  (res))

--- a/org-msg.el
+++ b/org-msg.el
@@ -520,7 +520,7 @@ during email generation where '&apos;' is turned into
   (let ((l))
     (save-excursion
       (goto-char (point-min))
-      (while (re-search-forward "\\\([a-zA-Z0-9, \-\\\._]+\\\) *{" nil t)
+      (while (re-search-forward "\\([a-zA-Z0-9, -\\._]+\\) *{" nil t)
 	(let ((selectors (split-string (match-string 1) "," nil " +"))
 	      (start (point))
 	      (props '()))
@@ -531,7 +531,7 @@ during email generation where '&apos;' is turned into
 	      (cl-multiple-value-bind (prop val) (split-string p ":" t "[\n ]*")
 		(push (cons (intern prop) val) props)))
 	    (dolist (sel selectors)
-	      (cl-multiple-value-bind (tag class) (split-string sel "\\\.")
+	      (cl-multiple-value-bind (tag class) (split-string sel "\\.")
 		(push (list (if (string= tag "") nil (intern tag))
 			    (if (stringp class) (intern class) nil)
 			    props)


### PR DESCRIPTION
Without this, the preview with <kbd>C-c C-e</kbd> and the final composed message do not display accented characters well.