### PR TITLE
Specify the desired coding style using .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((emacs-lisp-mode . ((indent-tabs-mode . t)
+		     (tab-width . 8))))


### PR DESCRIPTION
Since [I am](https://github.com/jeremy-compostella/org-msg/pull/91#discussion_r607234295) not [the only one](https://github.com/jeremy-compostella/org-msg/pull/84#discussion_r558882746) banning TABs by default, a `.dir-locals.el` specifying the default you desire is useful — it will work out of the box for every Emacs user.