### PR TITLE
Do not move the point when org-msg-edit-mode is not activated

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -1134,11 +1134,11 @@ area."
 	      (org-escape-code-in-region (point) (point-max))))
 	  (when org-msg-signature
 	    (insert org-msg-signature))
+	  (if (org-msg-message-fetch-field "to")
+	      (org-msg-goto-body)
+	    (message-goto-to))
 	  (org-msg-edit-mode))
-	(set-buffer-modified-p nil))
-      (if (org-msg-message-fetch-field "to")
-	  (org-msg-goto-body)
-	(message-goto-to)))))
+	(set-buffer-modified-p nil)))))
 
 (defun org-msg-post-setup--if-not-reply (&rest _args)
   "Helper for new mail setup vs reply in notmuch"


### PR DESCRIPTION
Without this, the point in moved to `(point-min)` because `org-msg-goto-body` does not find a signature nor an org-header.