### PR TITLE
Fix: Email domains may contain dashes (for org-msg-str-to-mailto)

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -608,7 +608,7 @@ style mailto anchor link style appropriately."
   (with-temp-buffer
     (insert str)
     (let ((name-regexp "\\([[:alpha:]\"][[:alnum:] ,\"()@./-]+\\)")
-	  (mail-regexp "<\\([A-Za-z0-9@.]+\\)>")
+	  (mail-regexp "<\\([A-Za-z0-9@.-]+\\)>")
 	  (cursor (goto-char (point-min)))
 	  (style (org-msg-build-style 'a org-msg-reply-header-class css))
 	  (res))


### PR DESCRIPTION
Signed-off-by: Christophe Troestler <Christophe.Troestler@umons.ac.be>