### PR TITLE
Possibly better default html styling for codeblocks (#115)

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -184,7 +184,7 @@ Can be either `top-posting' or nil."
 			     fundamental ini json makefile man org plantuml
 			     python sh xml))
 	 (inline-src `((color . ,(face-foreground 'default))
-		       (background-color . ,(face-background 'default))))
+		       (background-color . ,"#eeeeee")))
 	 (code-src
 	  (mapcar (lambda (mode)
 		    `(code ,(intern (concat "src src-" (symbol-name mode)))
@@ -230,7 +230,8 @@ Can be either `top-posting' or nil."
 		 (background-color . "#aaaaaa")))
     (pre nil ((line-height . "12pt")
 	      ,@inline-src
-	      (margin . "0px")
+	      (margin . "10px")
+-             (border . "2px solid #ccc")
 	      (font-size . "9pt")
 	      (font-family . "monospace")))
     (div org-src-container ((margin-top . "10px")))

--- a/org-msg.el
+++ b/org-msg.el
@@ -231,7 +231,7 @@ Can be either `top-posting' or nil."
     (pre nil ((line-height . "12pt")
 	      ,@inline-src
 	      (margin . "10px")
--             (border . "2px solid #ccc")
+              (border . "2px solid #ccc")
 	      (font-size . "9pt")
 	      (font-family . "monospace")))
     (div org-src-container ((margin-top . "10px")))


### PR DESCRIPTION
This does a few things
1. Creates a light grey background for src blocks
2. Adds a light grey border around codeblocks 
3. Adds some margins around the blocks to set them apart from nearby elements

The upside is that it looks pretty good:
![org-msg-change](https://user-images.githubusercontent.com/1871086/121560245-9f43a080-ca17-11eb-98ba-bcf2bac25099.png)

There are two downsides: 
1. If you have a light grey background, this hardcoded change won't help you very much visually- although it is probably no worse than the original.
2. Output blocks have the same grey shading. Ideally, I'd like them different, but again, this is no worse than the original
