### PR TITLE
Org msg dired attach

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -1287,6 +1287,16 @@ d       Delete one attachment, you will be prompted for a file name."))
     (cond ((memq c '(?a ?\C-a)) (call-interactively 'org-msg-attach-attach))
 	  ((memq c '(?d ?\C-d)) (call-interactively 'org-msg-attach-delete)))))
 
+(defun org-msg-dired-mail-buffers ()
+  "Return a list of active message buffers."
+  (let (buffers)
+    (save-current-buffer
+      (dolist (buffer (buffer-list t))
+        (set-buffer buffer)
+        (when (and (derived-mode-p 'org-msg-edit-mode)
+                   (null message-sent-message-via))
+          (push (buffer-name buffer) buffers))))
+    (nreverse buffers)))
 (defun org-msg-start ()
   "Return the point of the beginning of the message body."
   (save-excursion


### PR DESCRIPTION
Normal mu4e/gnus composing already supports selection of attachments via dired (`gnus-dired-attach`) and I missed this feature in _org-msg_, in particular for multiple attachments, as calling the attach dispatcher multiple times and navigating to different directories takes some time for me. 

This adds two function to the _org-msg_ namespace that clone the functionality of the corresponding `gnus-dired` functions, which are:
__org-msg-dired-mail-buffers__
- find open mail buffers in the `org-msg-edit-mode`

__org-msg-dired-attach__
- attaching the marked file(s) in a dired buffer to a new mail and open the mail edit buffer
- or choose one of the open _org-msg-edit_ buffers and attach the file(s) to that buffer

Ideally, `org-msg-dired-attach` can be bound to a key in the dired map.
