### PR TITLE
Feature request: defaultable attachment behaviour

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -108,6 +108,20 @@ Available alternatives are listed in `org-msg-alternative-exporters'."
   :type '(choice (list symbol)
 		 (list (alist symbol (list symbol)))))
 
+(defcustom org-msg-attach-default nil
+  "Default action for org-msg-attach.
+
+By default org-msg-attach (bound to `C-c C-a' by default) opens a
+dispatcher for you to attach a file, or delete an
+attachment. Setting this variable bypasses the dispatcher: set it
+to attach to always attach, or delete to always delete. Setting
+it to nil (the default) opens the dispatcher.
+
+Invoking org-msg-attach with a prefix argument always opens the
+dispatcher, regardless of this variable's value."
+  :type 'symbol
+  :options '(attach delete nil))
+
 (defcustom org-msg-greeting-fmt nil
   "Mail greeting format.
 If it contains a '%s' format, '%s' is replaced with the first
@@ -1279,7 +1293,7 @@ function is called.  `org-cycle' is called otherwise."
 	 (d (completing-read "File to remove: " files)))
     (org-msg-set-prop "attachment" (delete d files))))
 
-(defun org-msg-attach ()
+(defun org-msg-attach-dispatcher ()
   "The dispatcher for attachment commands.
 Shows a list of commands and prompts for another key to execute a
 command."
@@ -1298,6 +1312,15 @@ d       Delete one attachment, you will be prompted for a file name."))
 	(and (get-buffer "*Org Attach*") (kill-buffer "*Org Attach*"))))
     (cond ((memq c '(?a ?\C-a)) (call-interactively 'org-msg-attach-attach))
 	  ((memq c '(?d ?\C-d)) (call-interactively 'org-msg-attach-delete)))))
+
+(defun org-msg-attach (arg)
+  (interactive "P")
+  (if arg
+      (org-msg-attach-dispatcher)
+    (cl-case org-msg-attach-default
+      ('attach (call-interactively 'org-msg-attach-attach))
+      ('delete (call-interactively 'org-msg-attach-delete))
+      (t (org-msg-attach-dispatcher)))))
 
 (defun org-msg-dired-attach (orig-fun files-to-attach)
   "Attach dired's marked files to a OrgMsg message composition.


### PR DESCRIPTION
I find that I very rarely delete attachments, but I do *add* a lot of attachments. So, it would be convenient for me to be able to skip the step of pressing <kbd>a</kbd> in the dispatcher, by telling org-msg that I *always* want to add attachments, never delete them. We could do this with something like:

``` emacs-lisp
(setq org-msg-attach-default 'attach)
```

An implementation of this wouldn't break the current behaviour for those who are used to it, because the obvious thing to do is keep the dispatcher with both options if the variable is `nil`.

Of course I might *sometimes* want to delete attachments. To deal with this, perhaps `org-msg-attach` could always open the dispatcher (regardless of the variable above) when given a prefix argument. Another, similar possibility would be to give a direct keybinding to `org-msg-attach-delete`, so that the dispatcher could be similarly bypassed.