### PR TITLE
Feature request: send without exiting

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,7 +23,7 @@ The *OrgMsg* mode keys are the usual key combination used in either [[https://or
 - ~C-c C-s~ -- calls ~message-goto-subject~ (same as in [[https://www.gnu.org/software/emacs/manual/html_mono/message.html][Message mode]])
 - ~C-c C-b~ -- calls ~org-msg-goto-body~ (similar to ~message-goto-body~ in [[https://www.gnu.org/software/emacs/manual/html_mono/message.html][Message mode]])
 - ~C-c C-a~ -- calls ~org-msg-attach~, very similar to the ~org-attach~ function.  It lets you add or delete attachment for this email.  Attachment list is stored in the ~:attachment:~ property.
-- ~C-c C-c~ -- calls ~org-ctrl-c-ctrl-c~. *OrgMsg* configures ~org-msg-ctrl-c-ctrl-c~ as a final hook of [[https://orgmode.org/][Org mode]]. When ~org-msg-ctrl-c-ctrl-c~ is called in a *OrgMsg* buffer it generates the MIME message and send it.
+- ~C-c C-c~ -- calls ~org-ctrl-c-ctrl-c~. *OrgMsg* configures ~org-msg-ctrl-c-ctrl-c~ as a final hook of [[https://orgmode.org/][Org mode]]. When ~org-msg-ctrl-c-ctrl-c~ is called in a *OrgMsg* buffer it generates the MIME message, sends it and exits. If the universal argument is supplied, the last step is skipped.
 
 The ~org-msg-mode~ interactive function can be called to enable/disable *OrgMsg*.  By default, once the module is loaded, it is disable.  If you want to reply to an email without making use of *OrgMsg*, you should call that function before you call the reply-to function.
 

--- a/org-msg.el
+++ b/org-msg.el
@@ -1254,6 +1254,7 @@ MML tags."
   (unless (org-msg-message-fetch-field "subject")
     (org-msg-post-setup args)))
 
+(defalias 'org-msg-send-notmuch 'notmuch-mua-send)
 (defalias 'org-msg-send-and-exit-notmuch 'notmuch-mua-send-and-exit)
 
 (defun org-msg-sanity-check ()
@@ -1274,10 +1275,13 @@ to proceed?")
 (defun org-msg-ctrl-c-ctrl-c ()
   "Send message like `message-send-and-exit'.
 If the current buffer is OrgMsg buffer and OrgMsg is enabled (see
-`org-msg-toggle'), it calls `message-send-and-exit'."
+`org-msg-toggle'), it calls `message-send-and-exit'. With the
+universal prefix argument, it calls `message-send'."
   (when (eq major-mode 'org-msg-edit-mode)
     (org-msg-sanity-check)
-    (org-msg-mua-call 'send-and-exit 'message-send-and-exit)))
+    (if current-prefix-arg
+	(org-msg-mua-call 'send 'message-send)
+      (org-msg-mua-call 'send-and-exit 'message-send-and-exit))))
 
 (defun org-msg-tab ()
   "Complete names or Org mode visibility cycle.


### PR DESCRIPTION
Vanilla message-mode has a command `message-send`, which *just* sends the current message, without exitting. This is useful if you want to send the same or similar emails to different people separately. (Actually for me, it was useful for sending the same email to myself many times, iterating over different settings to get my emacs email setup just right.)

~Could similar functionality be implemented in org-msg? Perhaps it could just be bound to C-c C-u C-c.~ Yep, and this is the PR which does exactly that.