### PR TITLE
fix: make go-to-body ignore the signature

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -1356,11 +1356,8 @@ This function is used as an advice function of
   "Move point to the beginning of the message body."
   (interactive)
   (goto-char (point-min))
-  (if org-msg-signature
-      (when (search-forward org-msg-signature nil t)
-	(goto-char (match-beginning 0)))
-    (while (re-search-forward org-property-re nil t)
-      (forward-line))))
+  (while (re-search-forward org-property-re nil t)
+    (forward-line)))
 
 (defun org-msg-font-lock-make-header-matcher (regexp)
   "Create a function which look for REGEXP."


### PR DESCRIPTION
This was putting the cursor below quoted text, making replying much harder than
otherwise.