### PR TITLE
Don't activate org-msg mode when replying to icalendar event in mu4e

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -1426,8 +1426,11 @@ This function is used as an advice function of
 (defun org-msg-mode-mu4e ()
   "Setup the hook for mu4e mail user agent."
   (if org-msg-mode
-      (add-hook 'mu4e-compose-mode-hook 'org-msg-post-setup)
-    (remove-hook 'mu4e-compose-mode-hook 'org-msg-post-setup)))
+      (progn (add-hook 'mu4e-compose-mode-hook 'org-msg-post-setup)
+	     (advice-add 'mu4e-icalendar-reply
+			 :around #'org-msg-inhibited))
+    (remove-hook 'mu4e-compose-mode-hook 'org-msg-post-setup)
+    (advice-remove 'mu4e-icalendar-reply 'org-msg-inhibited)))
 
 (defun org-msg-mode-notmuch ()
   "Setup the hook for notmuch mail user agent."


### PR DESCRIPTION
Mu4e also supported icalendar invitations, so I added same advice as you added into gnus function.