### PR TITLE
Fix for mu 1.10 internals

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -1474,7 +1474,7 @@ HTML emails."
   "Setup mu4e faces, addresses completion and run mu4e."
   (mu4e~compose-remap-faces)
   (unless (mu4e-running-p)
-    (mu4e~start))
+    (if (fboundp #'mu4e~start) (mu4e~start) (mu4e--start)))
   (when mu4e-compose-complete-addresses
     (mu4e~compose-setup-completion))
   ;; the following code is verbatim from mu4e-compose.el, `mu4e-compose-mode'


### PR DESCRIPTION
Hello @jeremy-compostella, firstly, thank you for this awesome package.

The `mu4e~start` has been renamed (since 1.8 I guess) to `mu4e--start`.

See: https://github.com/djcb/mu/blob/release/1.10/NEWS.org#internals