### PR TITLE
Correct the type for `org-msg-default-alternatives`

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -107,7 +107,7 @@ but not to replies to plain text emails.
 
 Available alternatives are listed in `org-msg-alternative-exporters'."
   :type '(choice (list symbol)
-		 (list (alist symbol (list symbol)))))
+		 (alist :key-type symbol :value-type (repeat symbol))))
 
 (defcustom org-msg-greeting-fmt nil
   "Mail greeting format.


### PR DESCRIPTION
In Emacs 29.1, using `setopt` macro leads to a warning that `org-msg-default-alternatives` is of the wrong type. 

The correct type for the assoc-list should be 

```
(alist :key-type symbol :value-type (repeat symbol))
``` 

which can be validated by the fact that the following snippet returns `t`

```
(widget-apply
 (widget-convert '(choice (list symbol)
                  (alist :key-type symbol :value-type (repeat symbol))))
 :match
 '((new . (html))
   (reply-to-html . (html))))
```