### PR TITLE
Preserve the buffer-local value of user-mail-address

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -1212,7 +1212,12 @@ MML tags."
 	  (if (org-msg-message-fetch-field "to")
 	      (org-msg-goto-body)
 	    (message-goto-to))
-	  (org-msg-edit-mode))
+	  ;; Preserve the buffer-local value of user-mail-address to
+	  ;; ensure that message IDs generated from it will be using a
+	  ;; domain name that matches the sender.
+	  (let ((address user-mail-address))
+	    (org-msg-edit-mode)
+	    (setq-local user-mail-address address)))
 	(set-buffer-modified-p nil)))))
 
 (defun org-msg-post-setup--if-not-reply (&rest args)


### PR DESCRIPTION
When `message-make-fqdn` is called as part of constructing a message ID, the value of `user-mail-address` is likely to be used to provide the domain portion of the ID.  Restore the killed value of `user-mail-address` after `org-msg-edit-mode` is activated, to ensure that message IDs show a domain that matches the sender.

The let binding seemed a safer option than marking the symbol as `permanent-local`.
(I imagine that `user-mail-address` is likely to be referenced in other modes which are not related to sending mail.)