### PR TITLE
Add support to insert a mailto link to a recipient

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -1526,6 +1526,14 @@ HTML emails."
   (interactive)
   (org-msg-mua-call 'edit-kill-buffer 'message-kill-buffer))
 
+(defun org-msg-insert-recipient-mailto()
+  "Insert a mailto link to a recipient."
+  (interactive)
+  (let* ((recipients (message-all-recipients))
+	 (name (completing-read "Recipient: " recipients nil t))
+	 (address (car (assoc-default name recipients))))
+    (org-insert-link nil (concat "mailto:" address) (concat "@" name))))
+
 (defvar org-msg-edit-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map org-mode-map)
@@ -1534,6 +1542,7 @@ HTML emails."
     (define-key map (kbd "C-c C-k") 'org-msg-edit-kill-buffer)
     (define-key map (kbd "C-c C-s") 'message-goto-subject)
     (define-key map (kbd "C-c C-b") 'org-msg-goto-body)
+    (define-key map (kbd "C-c @") 'org-msg-insert-recipient-mailto)
     (define-key map [remap org-attach] 'org-msg-attach)
     map)
   "Keymap for `org-msg-edit-mode'.")


### PR DESCRIPTION
It has become more and more popular in the last few years to refer to a recipient of an email by adding a mailto link.  The `org-msg-insert-recipient-mailto' function can be use to insert such a mailto link. It is bound to "C-c @" in place of the default `org-mark-subtree' org-mode function.

This commit addresses #179.

Suggested-by: Alessio Bolognino (molok)