### PR TITLE
Changes to the final HTML document 

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -245,10 +245,11 @@ Can be either `top-posting' or nil."
 	      ,@inline-src
 	      (margin . "0px")
 	      (font-size . "9pt")
-	      (font-family . "monospace")))
+	      (font-family . "monospace")
+              (padding . "1.2em")
+              (border-radius . "3px")))
     (div org-src-container ((margin-top . "10px")))
     (nil figure-number ,ftl-number)
-    (nil table-number)
     (caption nil ((text-align . "left")
 		  (background . ,theme-color)
 		  (color . "white")
@@ -259,7 +260,7 @@ Can be either `top-posting' or nil."
     (nil figure ,ftl-number)
     (nil org-src-name ,ftl-number)
 
-    (table nil (,@table ,line-height (border-collapse . "collapse")))
+    (table nil (,@table ,line-height (border-collapse . "collapse") (margin . "1em 0")))
     (th nil ((border . "1px solid white")
 	     (background-color . ,theme-color)
 	     (color . "white")
@@ -286,7 +287,11 @@ Can be either `top-posting' or nil."
     (p nil ((text-decoration . "none") (margin-bottom . "0px")
 	    (margin-top . "10px") (line-height . "11pt") ,font-size
 	    ,font-family))
-    (div nil (,@font (line-height . "11pt"))))))
+    (div nil (,@font (line-height . "11pt") (overflow . "auto")))
+    (nil nil content ((max-width . "69ch")
+                      (margin . "0 auto")))
+    (img nil nil ((width . "100%")
+                  (border-radius . "3px"))))))
 
 (defcustom org-msg-enforce-css org-msg-default-style
   "Define how to handle CSS style:


### PR DESCRIPTION
Without being to opinionated on taste it adds the following:

- padding on code blocks (for better readability)
- center and restrict "id=content" element to a comfortable read size
- images are set to "width: 100%" to fit properly
- "margin: 1em 0" on table elements to prevent the scroll bar from
  overlapping the table last row
- small border radius on elements with background, like images and
  code blocks (this one is a bit opinionated, but I argue those sharp
  corner could be dangerous)

Here's an image to see the differences:

![org-msg-diff small](https://github.com/user-attachments/assets/c346070e-1993-42f4-901a-f736725256a7)
