### PR TITLE
feat(org-msg-css-to-file): save current css to file

### DIFF
--- a/org-msg-test.el
+++ b/org-msg-test.el
@@ -1,0 +1,16 @@
+(ert-deftest org-msg-test-css-parsing ()
+  "Test css list to string and back is consistant."
+  (let* ((css-list   (org-msg-load-css))
+	 (css-string  (org-msg-css-to-string))
+	 (css-string-list (with-temp-buffer
+			   (insert css-string)
+			   (org-msg-css-to-list))))
+  (should (equal (car css-list) (car css-string-list)))
+  (should (equal css-list css-string-list))))
+
+(ert-deftest org-msg-test-css-1 ()
+  "Simple css prop to string test."
+  (should (equal (org-msg-props-to-style
+		  '((color . "red")
+		    (background . "blue")))
+		 "color:red;background:blue;")))

--- a/org-msg.el
+++ b/org-msg.el
@@ -490,10 +490,15 @@ during email generation where '&apos;' is turned into
 		(push (cons (intern prop) val) props)))
 	    (dolist (sel selectors)
 	      (cl-multiple-value-bind (tag class) (split-string sel "\\.")
-		(push (list (if (string= tag "") nil (intern tag))
-			    (if (stringp class) (intern class) nil)
-			    props)
-		      l)))))))
+		(let ((tag (if (string= tag "") nil (intern tag)) )
+		      (class (if (stringp class) (intern class) nil)))
+		  (push
+		   ;; to match `org-msg-default-style' we need
+		   ;; (nil table-number) not (nil table-number nil)
+		   (if props
+		       (list tag class props)
+		       (list tag class))
+		   l))))))))
     l))
 
 (defun org-msg-css-file-to-list (file)
@@ -509,6 +514,33 @@ See `org-msg-css-to-list'."
 	      (concat (symbol-name (car css)) ":"
 		      (cdr css) ";")))
     (apply 'concat (mapcar #'css-str props))))
+
+(defun org-msg-css-to-string ()
+  "Combine `org-msg-load-css' (likely `org-msg-default-style') as CSS."
+  (let (allcss)
+    (dolist (el (org-msg-load-css) allcss)
+      (cl-multiple-value-bind (tag class css) el
+        (push (concat
+          (when tag (symbol-name tag))
+          (when class (concat "." (symbol-name class)))
+	  ;; reverse to match how list is stored
+          "{" (org-msg-props-to-style (reverse css)) "}")
+         allcss)))
+    (string-join allcss "\n")))
+
+(defun org-msg-css-to-file (fname)
+  "Format list output of `org-msg-load-css' as CSS and save to `FNAME'.
+By default, style is from `org-msg-default-style'
+and will be based on your current Emacs theme.
+Alternatively, `org-msg-enforce-css' could be set to `FNAME'
+to customize the your email's style based on the exported css file.
+Note: the file is parsed and styles are inlined for every html element.
+The file is NOT used like <link rel=... >."
+  (interactive "Fcss ouptut file:")
+  (with-temp-buffer
+    (insert (org-msg-css-to-string))
+    (write-file fname))
+  (find-file fname))
 
 (defsubst org-msg-in-quote-block ()
   "Whether point is in a quote block."


### PR DESCRIPTION
Thank you for sharing this package! As mentioned elsewhere in the repo issues, it brought me back to emailing with emacs.

I wanted to make style changes similar to #116 (edit: also #196)  -- border around code blocks. And a bit like  #174, I'm looking for an easy way to add my own styling. But  was pretty intimidated by starting a file from scratch.
It looks like `org-msg-props-to-style` doesn't need much more to be able to write out a complete file based on the default style. I did that with `org-msg-css-to-string` and added as an interactive interface `org-msg-css-to-file`

Now I call  `org-msg-css-to-file`, make small edits to the file, and set `org-msg-enforce-css` to the new file with my modifications.


I also added a test to confirm prop list -> file -> prop list is all consistent. To get that to work a small change to `org-msg-css-to-list` was needed: the property list for an empty css rule has 2 elements instead of 3 (originally the 3rd was null). 
```
(nil table-number)      ; as in org-msg-default-style
(nil table-number nil)  ; but 3rd element=nil was originally generated
```
