### PR TITLE
fixes #200

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -1553,7 +1553,8 @@ Type \\[org-msg-attach] to call the dispatcher for attachment
 \\{org-msg-edit-mode-map}"
   (setq-local message-sent-message-via nil)
   (add-hook 'message-send-hook 'org-msg-prepare-to-send nil t)
-  (add-hook 'message-sent-hook 'undo t t)
+  (if (not (equal mail-user-agent #'mu4e-user-agent))
+      (add-hook 'message-sent-hook 'undo t t))
   (add-hook 'completion-at-point-functions 'message-completion-function nil t)
   (cond ((message-mail-alias-type-p 'abbrev) (mail-abbrevs-setup))
 	((message-mail-alias-type-p 'ecomplete) (ecomplete-setup)))


### PR DESCRIPTION
remove undo from message-sent-hook as it was causing an error and for html drafts to be sent after successful message sending (unintended behavior).

Also discussed in #182 where the hook was suspected to be causing problems https://github.com/jeremy-compostella/org-msg/issues/182

Note, in #182 multiple users report no issues after removing hook. 