### PR TITLE
mu4e htmlp non-detection for draft messages

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -1120,7 +1120,7 @@ a html mime part, it returns t, nil otherwise."
     (org-msg-article-htmlp)))
 
 (defun org-msg-article-htmlp-mu4e ()
-  (let ((msg mu4e-compose-parent-message))
+  (when-let ((msg mu4e-compose-parent-message))
     (with-temp-buffer
       (insert-file-contents-literally
        (mu4e-message-readable-path msg) nil nil nil t)


### PR DESCRIPTION
Draft messages don't have a parent and it leads to a mu4e error when trying to edit them:

>    No message at point

This fix is needed for draft messages that have a subject line, due to https://github.com/jeremy-compostella/org-msg/blob/59e2042e5f23e25f31c6aef0db1e70c6f54f117d/org-msg.el#L1184-L1185