### PR TITLE
Remove forbidden properties

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -1556,6 +1556,8 @@ Type \\[org-msg-attach] to call the dispatcher for attachment
   (if (not (equal mail-user-agent #'mu4e-user-agent))
       (add-hook 'message-sent-hook 'undo t t))
   (add-hook 'completion-at-point-functions 'message-completion-function nil t)
+  (add-hook 'after-change-functions #'message-strip-forbidden-properties
+	    nil 'local)
   (cond ((message-mail-alias-type-p 'abbrev) (mail-abbrevs-setup))
 	((message-mail-alias-type-p 'ecomplete) (ecomplete-setup)))
   (setq org-font-lock-keywords

--- a/org-msg.el
+++ b/org-msg.el
@@ -1553,7 +1553,8 @@ Type \\[org-msg-attach] to call the dispatcher for attachment
 \\{org-msg-edit-mode-map}"
   (setq-local message-sent-message-via nil)
   (add-hook 'message-send-hook 'org-msg-prepare-to-send nil t)
-  (add-hook 'message-sent-hook 'undo t t)
+  (if (not (equal mail-user-agent #'mu4e-user-agent))
+      (add-hook 'message-sent-hook 'undo t t))
   (add-hook 'completion-at-point-functions 'message-completion-function nil t)
   (cond ((message-mail-alias-type-p 'abbrev) (mail-abbrevs-setup))
 	((message-mail-alias-type-p 'ecomplete) (ecomplete-setup)))


### PR DESCRIPTION
This change (motivated by the investigation [here](https://github.com/jeremy-compostella/org-msg/pull/201#issuecomment-2585940940), adopts infrastructure from message-mode to strip the read-only property from any text inserted into an org-msg compose buffer.

This matches the behavior of mu4e's buffer, and prevents an issue where mu4e adds read-only text which message-send can't correctly process.