### PR TITLE
Some mu4e fixes (#200, draft not removed, draft editing issues (tested in v1.12.8)

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -1120,7 +1120,7 @@ a html mime part, it returns t, nil otherwise."
     (org-msg-article-htmlp)))
 
 (defun org-msg-article-htmlp-mu4e ()
-  (let ((msg mu4e-compose-parent-message))
+  (when-let* ((msg mu4e-compose-parent-message))
     (with-temp-buffer
       (insert-file-contents-literally
        (mu4e-message-readable-path msg) nil nil nil t)
@@ -1551,7 +1551,7 @@ Type \\[org-msg-attach] to call the dispatcher for attachment
 \\{org-msg-edit-mode-map}"
   (setq-local message-sent-message-via nil)
   (add-hook 'message-send-hook 'org-msg-prepare-to-send nil t)
-  (if (not (equal mail-user-agent #'mu4e-user-agent))
+  (unless (eq mail-user-agent #'mu4e-user-agent)
       (add-hook 'message-sent-hook 'undo t t))
   (add-hook 'completion-at-point-functions 'message-completion-function nil t)
   (add-hook 'after-change-functions #'message-strip-forbidden-properties


### PR DESCRIPTION
This PR builds on top of #204 and #201  to fix several issues:
- fixes #200 (see #204 and #201)
- draft are now removed when the message is sent (see discussion in #204)
- when a draft was saved, editing it was leading to `mu4e-warn: [mu4e] No message at point`. This PR (especially the commit e7b5447ab07a853a9e85fa2fe361903acab5670d) fixes this as well

I did my best to test the different commits, but I didn't systematize it.