### PR TITLE
fix: #141 (ensure that emails which are not mml are really detected as mml

### DIFF
--- a/org-msg.el
+++ b/org-msg.el
@@ -992,8 +992,8 @@ This function is a hook for `message-send-hook'."
           ;; about this if we are only sending text/plain
           (if (or (org-msg-mml-recursive-support)
                   (not (memq 'html alternatives)))
-              (progn
-                (when (or attachments mml)
+	      (progn
+                (when (or attachments (and (not (string-empty-p mml)) mml))
                   (mml-insert-multipart "mixed"))
                 (when (> (length org-msg-alternatives) 1)
                   (mml-insert-multipart "alternative"))


### PR DESCRIPTION
mml is returned at one point as an empty string if not defined